### PR TITLE
Make fontelloUpdate a multiTask to specify different targets with different actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "load-grunt-tasks": "~3.0.0",
-    "fontello-update": "erdii/fontello-update",
+    "fontello-update": "~0.6.1",
     "grunt-contrib-clean": "~0.6.0",
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.11.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "load-grunt-tasks": "~3.0.0",
-    "fontello-update": "~0.6.1",
+    "fontello-update": "erdii/fontello-update",
     "grunt-contrib-clean": "~0.6.0",
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.11.0"

--- a/tasks/fontello-update.js
+++ b/tasks/fontello-update.js
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
 
 	var fontelloUpdate = require('fontello-update');
 
-	grunt.registerTask('fontelloUpdate', 'Update font files given a fontello config', function() {
+	grunt.registerMultiTask('fontelloUpdate', 'Update font files given a fontello config', function() {
 
 		var done    = this.async()
 		  , options = this.options({


### PR DESCRIPTION
This pull request comes in combination with another pull request on `fontello-update`.

Example:
```
fontelloUpdate: {
    options: {
      config: 'path/to/fontello/config.json'
    },
    edit: {
      options: {
        open: true
      }
    },
    update: {
      options: {
        fonts: 'path/to/fonts/',
        css: 'path/to/css'
      }
    }
  }
```